### PR TITLE
EventHub SDK stops reading from certain partitions. 

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,8 +10,6 @@ consumer.trackLastEnqueuedEventProperties = true
 consumer.fully-qualified-namespace = 
 consumer.event-hub-name = 
 
-eventhub-partition.max-duration-of-inactivity = PT5M
-
 in-memory.checkpoint-after-events = 1000
 
 management.metrics.tags.environment = dev


### PR DESCRIPTION
To identify and trigger a restart when that happens, periodically fetch the claimed partitions and check if sequence number is changing over time or not.